### PR TITLE
Prepare for 0.0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `postgresql-simple-named` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.0.1.0 — Jul 23, 2019
+
+* [#16](https://github.com/holmusk/postgresql-simple-named/issues/16):
+  Implement `queryWithNamed`.
+
 ## 0.0.0.0 — Jul 11, 2019
 
 * Initially created.

--- a/postgresql-simple-named.cabal
+++ b/postgresql-simple-named.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                postgresql-simple-named
-version:             0.0.0.0
+version:             0.0.1.0
 synopsis:            Implementation of named parameters for `postgresql-simple` library
 description:
     Implementation of named parameters for @postgresql-simple@ library.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-13.27
+resolver: lts-13.29


### PR DESCRIPTION
I also improved documentation in some places to make the package look even cooler. Specifically:

* Made SQL keywords bold (because why not? It seems even juicier)
* Added more hyperlinks
* Reword documentation for `queryWithNamed`. It was too much text
* I've used `stock` strategies everywhere for cleaner code
* Reexported `withNamedArgs` to make integration with named parameters easier