### PR TITLE
[#19] Implement returningNamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `postgresql-simple-named` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## Unreleased
+
+* [#19](https://github.com/holmusk/postgresql-simple-named/issues/19):
+  Implement `returningNamed` function.
+
 ## 0.0.1.0 — Jul 23, 2019
 
 * [#16](https://github.com/holmusk/postgresql-simple-named/issues/16):


### PR DESCRIPTION
Resolves #19

By the docs [`returning`](https://hackage.haskell.org/package/postgresql-simple-0.6.2/docs/Database-PostgreSQL-Simple.html#v:returning) should receive the *list* of `q`s, not a single row as `execute`, so I just put args into the list. I'm not sure if in such form it's fully valid. Please advice.