### PR TITLE
lift IO exceptions from PG to MonadError

### DIFF
--- a/src/PgNamed.hs
+++ b/src/PgNamed.hs
@@ -315,3 +315,4 @@ handleIO io = do
     case res of
         Right a  -> pure a
         Left err -> throwError $ PgSqlError err
+{-# INLINE handleIO #-}

--- a/src/PgNamed.hs
+++ b/src/PgNamed.hs
@@ -84,6 +84,7 @@ data PgNamedError
     | PgNoNames PG.Query
     -- | Query contains an empty name.
     | PgEmptyName PG.Query
+    -- | Query failed to evaluate due to database error.
     | PgSqlError PG.SqlError
     deriving stock (Eq)
 


### PR DESCRIPTION
This is proof of concept solution for #27

Unfortunately this is hard to test using current testing approach which seems not to be really queering any real DB table even though it requires database connection.

```
$ psql -h localhost -p 5432 -U postgres -n pg_named
psql (11.6, server 10.5)
Type "help" for help.

pg_named=# \dt
Did not find any relations.
pg_named=# 
```