### PR TITLE
Test with ghc 8.10.2 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,16 @@ matrix:
   include:
   - ghc: 8.4.4
   - ghc: 8.6.5
-  - ghc: 8.8.3
+  - ghc: 8.8.4
+  - ghc: 8.10.2
 
   # stack
   - ghc: 8.4.4
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.4.4.yaml"
   - ghc: 8.6.5
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.6.5.yaml"
-  - ghc: 8.8.3
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
+  - ghc: 8.8.4
+    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.8.4.yaml"
 
 install:
   # HLint check
@@ -51,7 +52,7 @@ before_script:
 script:
   - |
     if [ -z "$STACK_YAML" ]; then
-       cabal test --enable-tests
+      cabal test --enable-tests
     else
       stack test --system-ghc
     fi

--- a/postgresql-simple-named.cabal
+++ b/postgresql-simple-named.cabal
@@ -30,7 +30,8 @@ extra-doc-files:     README.md
                    , CHANGELOG.md
 tested-with:         GHC == 8.4.4
                    , GHC == 8.6.5
-                   , GHC == 8.8.2
+                   , GHC == 8.8.4
+                   , GHC == 8.10.2
 
 source-repository head
   type:                git

--- a/postgresql-simple-named.cabal
+++ b/postgresql-simple-named.cabal
@@ -49,6 +49,10 @@ common common-options
                        -fhide-source-paths
                        -Wmissing-export-lists
                        -Wpartial-fields
+  if impl(ghc >= 8.8)
+    ghc-options:       -Wmissing-deriving-strategies
+  if impl(ghc >= 8.10)
+    ghc-options:       -Wunused-packages
 
   default-language:    Haskell2010
   default-extensions:  ConstraintKinds

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,0 +1,1 @@
+resolver: lts-16.18

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,0 @@
-resolver: lts-16.2


### PR DESCRIPTION
The idea of this PR is to future proof this package by adding CI check that it can still build with stackage LTS which is based on ghc 8.10.x. For now that GHC is only in stackage nightly, but in this PR I at least add a build step with cabal + GHC 8.10.2