### PR TITLE
Prepare for 0.0.4.0 release

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -19,6 +19,7 @@ jobs:
           - 8.10.7
           - 9.0.2
           - 9.2.4
+          - 9.4.2
     services:
       postgres:
         image: postgres:15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 `postgresql-simple-named` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 0.0.4.0 - Nov 2, 2022
+
+* Add support for GHC 9.2 and 9.4
+
 ## 0.0.3.0 - Jun 1, 2022
 
-* Adds support for GHC 8.10 and 9.0
+* Add support for GHC 8.10 and 9.0
 * [#30](https://github.com/Holmusk/postgresql-simple-named/issues/30):
   Fixes a bug with postgres-simple-named not recognising postgres JSON operators 
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![Logo](https://user-images.githubusercontent.com/4276606/68105647-408b7c00-fef0-11e9-8d70-d3fbf314a647.png)
 
-[![Build status](https://img.shields.io/travis/Holmusk/postgresql-simple-named.svg?logo=travis)](https://travis-ci.org/Holmusk/postgresql-simple-named)
+[![Build status](https://github.com/Holmusk/postgresql-simple-named/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/Holmusk/postgresql-simple-named/actions/workflows/haskell-ci.yml)
 [![Hackage](https://img.shields.io/hackage/v/postgresql-simple-named.svg?logo=haskell)](https://hackage.haskell.org/package/postgresql-simple-named)
 [![Stackage Lts](http://stackage.org/package/postgresql-simple-named/badge/lts)](http://stackage.org/lts/package/postgresql-simple-named)
 [![Stackage Nightly](http://stackage.org/package/postgresql-simple-named/badge/nightly)](http://stackage.org/nightly/package/postgresql-simple-named)
 [![MPL-2.0 license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](LICENSE)
 
 This library introduces the implementation of named parameters for the
-[`postgresql-simple`][pgs] library. `postgresql-simple-named` is considered to
+[`postgresql-simple`][pgs] library. `postgresql-simple-named` is designed to
 be used along with the [`postgresql-simple`][pgs] library, so you could refer
 there for the original documentation of primary functions. This package solves
 exclusively one particular problem — gives the ability to use named parameters

--- a/postgresql-simple-named.cabal
+++ b/postgresql-simple-named.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                postgresql-simple-named
-version:             0.0.3.0
+version:             0.0.4.0
 synopsis:            Implementation of named parameters for `postgresql-simple` library
 description:
     Implementation of named parameters for @postgresql-simple@ library.
@@ -31,13 +31,14 @@ extra-source-files:  README.md
 tested-with:         GHC == 8.10.7
                    , GHC == 9.0.2
                    , GHC == 9.2.4
+                   , GHC == 9.4.2
 
 source-repository head
   type:                git
   location:            https://github.com/Holmusk/postgresql-simple-named.git
 
 common common-options
-  build-depends:       base >= 4.11 && < 4.17
+  build-depends:       base >= 4.11 && < 4.18
 
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,1 +1,1 @@
-resolver: lts-19.30
+resolver: lts-19.31


### PR DESCRIPTION
I'd like to publish ghc 9.2 and 9.4 compliant version to hackage based on this commit.